### PR TITLE
Strip off SSID for login purposes

### DIFF
--- a/pypacket/implementations/aprs_is_processor.py
+++ b/pypacket/implementations/aprs_is_processor.py
@@ -29,6 +29,10 @@ class AprsIsProcessor(Processor):
         self.log_handler = log_handler
 
         username = self.config.username()
+
+        # Strip SSID from username for APRS-IS login
+        username = username.split("-")[0].strip()
+
         password = self.config.password()
 
         if not username or not password:


### PR DESCRIPTION
Leave SSID intact for beaconing though.

Fixes #64
